### PR TITLE
Update branch to most recent release, remove Branch API calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,5 +11,5 @@ buildscript {
 apply plugin: 'com.mparticle.kit'
 
 dependencies {
-    compile 'io.branch.sdk.android:library:1.14.5'
+    compile 'io.branch.sdk.android:library:2.5.7'
 }

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,1 +1,4 @@
-<manifest package="com.mparticle.kits.branch"/>
+<manifest package="com.mparticle.kits.branch"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-sdk tools:overrideLibrary="io.branch.referral"/>
+</manifest>

--- a/src/main/java/com/mparticle/kits/BranchMetricsKit.java
+++ b/src/main/java/com/mparticle/kits/BranchMetricsKit.java
@@ -13,7 +13,6 @@ import com.mparticle.MParticle;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.math.BigDecimal;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +85,6 @@ public class BranchMetricsKit extends KitIntegration implements KitIntegration.A
                 }
             }
         }
-        getBranch().userCompletedAction(event.getEventName(), jsonAttributes);
         List<ReportingMessage> messages = new LinkedList<ReportingMessage>();
         messages.add(ReportingMessage.fromEvent(this, event));
         return messages;
@@ -115,7 +113,6 @@ public class BranchMetricsKit extends KitIntegration implements KitIntegration.A
 
     @Override
     public List<ReportingMessage> onActivityStopped(Activity activity) {
-        getBranch().closeSession();
         List<ReportingMessage> messageList = new LinkedList<ReportingMessage>();
         messageList.add(
                 new ReportingMessage(this, ReportingMessage.MessageType.APP_STATE_TRANSITION, System.currentTimeMillis(), null)
@@ -185,9 +182,6 @@ public class BranchMetricsKit extends KitIntegration implements KitIntegration.A
 
     @Override
     public void setUserIdentity(MParticle.IdentityType identityType, String s) {
-        if (identityType == MParticle.IdentityType.CustomerId) {
-            getBranch().setIdentity(s);
-        }
     }
 
     @Override
@@ -197,7 +191,6 @@ public class BranchMetricsKit extends KitIntegration implements KitIntegration.A
 
     @Override
     public List<ReportingMessage> logout() {
-        getBranch().logout();
         List<ReportingMessage> messageList = new LinkedList<ReportingMessage>();
         messageList.add(ReportingMessage.logoutMessage(this));
         return messageList;


### PR DESCRIPTION
[Issue #100](https://github.com/mParticle/android-sdk-internal/issues/100)

removed 3 remote api calls within the Branch sdk, as well as depreciated call to Logout().

Updated Branch sdk version, and overrode minSDK , since Branch upped support from > 9 to > 15 since last version

removed unused import, BigDecimal