### PR TITLE
Enable setting customer event alias

### DIFF
--- a/src/main/java/com/mparticle/kits/BranchUtil.java
+++ b/src/main/java/com/mparticle/kits/BranchUtil.java
@@ -304,6 +304,9 @@ class BranchUtil {
     void updateBranchEventWithCustomData(BranchEvent branchEvent, Map<String, String> eventAttributes) {
         for (String key : eventAttributes.keySet()) {
             branchEvent.addCustomDataProperty(key, eventAttributes.get(key));
+            if (key.equals("customer_event_alias")) {
+                branchEvent.setCustomerEventAlias(eventAttributes.get(key));
+            }
         }
     }
 


### PR DESCRIPTION
If a customer sets a custom attribute with key "customer_event_alias" we should set this on the Branch SDK as the Customer Event Alias