### PR TITLE
fix: add getAutoInstance to onKitCreate

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/BranchMetricsKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/BranchMetricsKit.kt
@@ -40,15 +40,17 @@ class BranchMetricsKit : KitIntegration(), KitIntegration.EventListener, Commerc
     override fun getName(): String = NAME
 
     override fun onKitCreate(
-        settings: Map<String, String>,
-        context: Context
-    ): List<ReportingMessage> {
+        settings: Map<String?, String?>,
+        context: Context?
+    ): List<ReportingMessage?>? {
         branchUtil = BranchUtil()
         Branch.disableDeviceIDFetch(!MParticle.isAndroidIdEnabled())
         Branch.registerPlugin(
             "mParticle",
-            javaClass.getPackage()?.specificationVersion ?: "0"
+            if (javaClass.getPackage() != null) javaClass.getPackage()?.specificationVersion else "0"
         )
+        getSettings()[BRANCH_APP_KEY]
+            ?.let { Branch.getAutoInstance(getContext().applicationContext, it) }
         Branch.sessionBuilder(null).withCallback(this).init()
         if (Logger.getMinLogLevel() != MParticle.LogLevel.NONE) {
             Branch.enableLogging()
@@ -57,10 +59,10 @@ class BranchMetricsKit : KitIntegration(), KitIntegration.EventListener, Commerc
         mSendScreenEvents =
             sendScreenEvents != null && sendScreenEvents.equals("true", ignoreCase = true)
         setIdentityType(settings)
-        return emptyList()
+        return null
     }
 
-    fun setIdentityType(settings: Map<String, String>) {
+    fun setIdentityType(settings: Map<String?, String?>) {
         val userIdentificationType = settings[USER_IDENTIFICATION_TYPE]
 
         userIdentificationType?.let {

--- a/src/main/kotlin/com/mparticle/kits/BranchMetricsKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/BranchMetricsKit.kt
@@ -40,14 +40,14 @@ class BranchMetricsKit : KitIntegration(), KitIntegration.EventListener, Commerc
     override fun getName(): String = NAME
 
     override fun onKitCreate(
-        settings: Map<String?, String?>,
-        context: Context?
-    ): List<ReportingMessage?>? {
+        settings: Map<String, String>,
+        context: Context
+    ): List<ReportingMessage> {
         branchUtil = BranchUtil()
         Branch.disableDeviceIDFetch(!MParticle.isAndroidIdEnabled())
         Branch.registerPlugin(
             "mParticle",
-            if (javaClass.getPackage() != null) javaClass.getPackage()?.specificationVersion else "0"
+            javaClass.getPackage()?.specificationVersion ?: "0"
         )
         getSettings()[BRANCH_APP_KEY]
             ?.let { Branch.getAutoInstance(getContext().applicationContext, it) }
@@ -59,10 +59,10 @@ class BranchMetricsKit : KitIntegration(), KitIntegration.EventListener, Commerc
         mSendScreenEvents =
             sendScreenEvents != null && sendScreenEvents.equals("true", ignoreCase = true)
         setIdentityType(settings)
-        return null
+        return emptyList()
     }
 
-    fun setIdentityType(settings: Map<String?, String?>) {
+    fun setIdentityType(settings: Map<String, String>) {
         val userIdentificationType = settings[USER_IDENTIFICATION_TYPE]
 
         userIdentificationType?.let {


### PR DESCRIPTION
## Summary
- Added getAutoInstance to onKitCreate to resolve Branch initialization issue.

## Testing Plan
- Tested by importing kit locally

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4685
