### PR TITLE
chore: bump Branch SDK version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,5 +40,5 @@ android {
 }
 
 dependencies {
-    api 'io.branch.sdk.android:library:5.10.1'
+    api 'io.branch.sdk.android:library:5.12.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -40,5 +40,5 @@ android {
 }
 
 dependencies {
-    api 'io.branch.sdk.android:library:5.2.7'
+    api 'io.branch.sdk.android:library:5.10.1'
 }

--- a/src/main/kotlin/com/mparticle/kits/BranchMetricsKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/BranchMetricsKit.kt
@@ -14,7 +14,7 @@ import com.mparticle.kits.KitIntegration.*
 import io.branch.referral.Branch
 import io.branch.referral.Branch.BranchReferralInitListener
 import io.branch.referral.BranchError
-import io.branch.referral.PrefHelper
+import io.branch.referral.BranchLogger
 import io.branch.referral.util.BranchEvent
 import org.json.JSONObject
 import java.math.BigDecimal
@@ -151,10 +151,11 @@ class BranchMetricsKit : KitIntegration(), KitIntegration.EventListener, Commerc
     }
 
     private val branch: Branch?
-        get() = settings[BRANCH_APP_KEY]?.let { Branch.getInstance(context, it) }
+        get() = settings[BRANCH_APP_KEY]?.let { Branch.getInstance() }
+
 
     override fun setInstallReferrer(intent: Intent) {
-        PrefHelper.LogAlways("setInstallReferrer(intent) was ignored, INSTALL_REFERRER broadcast intent is deprecated, relevant data is now collected automatically using the Play Install Referrer Library bundled together with Branch SDK.")
+        BranchLogger.w("setInstallReferrer(intent) was ignored, INSTALL_REFERRER broadcast intent is deprecated, relevant data is now collected automatically using the Play Install Referrer Library bundled together with Branch SDK.")
     }
 
     override fun setUserAttribute(s: String, s1: String) {}


### PR DESCRIPTION
 ## Summary
Updated the Branch Android SDK's version from 5.2.7 to the latest, 5.10.1. 
The code updates were to the get() call and and update to use the BranchLogger class. Please let me know if there are any other changes required or if you need any more information from me.

It's important for us to get the update our quickly to give our clients access to the latest version of Branch.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
- I was unable to get the provided SampleApplication to work
