### PR TITLE
fix: Removed Branch.disableDeviceIDFetch(!MParticle.isAndroidIdEnabled()) from onKitCreate

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/BranchMetricsKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/BranchMetricsKit.kt
@@ -44,7 +44,6 @@ class BranchMetricsKit : KitIntegration(), KitIntegration.EventListener, Commerc
         context: Context
     ): List<ReportingMessage> {
         branchUtil = BranchUtil()
-        Branch.disableDeviceIDFetch(!MParticle.isAndroidIdEnabled())
         Branch.registerPlugin(
             "mParticle",
             javaClass.getPackage()?.specificationVersion ?: "0"


### PR DESCRIPTION
Teams were concerned about setting debug = true automatically. In removing this code, we are giving teams the option of setting debug = true down the line instead of on initialization.

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary

- Branch.disableDeviceIDFetch(!MParticle.isAndroidIdEnabled()) has been removed from the onKitCreate function of the BranchMetricsKit.kt file.
- Previously, this line was setting a branch SDK boolean received on installs and opens named "debug" to "true" if the androidID was disabled. This caused issue with reinstalls not being counted as the SDK was functioning in debug mode.

 ## Testing Plan
 - This was tested locally by adding this build to the mparticle testing app and performing an install and open and verifying the debug = false logs in the install output data.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
